### PR TITLE
Move the git oauth key to the secrets config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .DS_Store
 whitesource/
 *.swp
+.project
+.pydevproject

--- a/config.py
+++ b/config.py
@@ -114,6 +114,7 @@ def loadSecrets():
 
             secrets = Secrets()
             default_oauth = js.get("default_github_oauth", "")
+            secrets._default_oauth = default_oauth
             # expecting mapping of prj name to JiraSecret data
             project_data = js.get("projects", {})
             for prj, prj_dict in project_data.items():
@@ -219,10 +220,14 @@ def loadConfig(configFilename, scaffoldHome):
                 return cfg
 
             for prj_name, prj_dict in projects_dict.items():
+                #TODO: Refactor this function - cognative and cyclomatic complexity is high
                 prj = Project()
                 prj._name = prj_name
                 prj._ok = True
-
+                if not prj_name in cfg._secrets._gitoauth:
+                # Update the secrets for any missing project data
+                    cfg._secrets._gitoauth[prj_name] = cfg._secrets._default_oauth
+                
                 prj._cycle = prj_dict.get('cycle', 99)
 
                 # get project status

--- a/config.py
+++ b/config.py
@@ -5,7 +5,6 @@ import json
 import os
 from pathlib import Path
 from shutil import copyfile
-import pdb
 
 import yaml
 
@@ -108,7 +107,6 @@ def loadFindings(findingsFilename):
 
 # parses secrets file; always looks in ~/.scaffold-secrets.json
 def loadSecrets():
-    pdb.set_trace()
     secretsFile = os.path.join(Path.home(), ".scaffold-secrets.json")
     try:
         with open(secretsFile, 'r') as f:

--- a/datatypes.py
+++ b/datatypes.py
@@ -371,6 +371,9 @@ class Secrets:
 
         # mapping of project name to WhiteSource server details
         self._ws = {}
+        
+        # mapping of project name to Github OAUTH tokens
+        self._gitoauth = {}
 
 
 class Config:
@@ -393,7 +396,6 @@ class Config:
         self._ws_unified_agent_jar_path = ""
         self._ws_default_env = {}
         # DO NOT OUTPUT THESE TO CONFIG.JSON
-        self._gh_oauth_token = ""
         self._secrets = None
 
     def __repr__(self):

--- a/datatypes.py
+++ b/datatypes.py
@@ -374,6 +374,9 @@ class Secrets:
         
         # mapping of project name to Github OAUTH tokens
         self._gitoauth = {}
+        
+        # default git outh for projects that do not have a configured oauth
+        self._default_gitoauth = ""
 
 
 class Config:

--- a/docs/config.md
+++ b/docs/config.md
@@ -117,3 +117,16 @@ Within the subproject's object are the following fields:
 * `code`: an object storing data relating to code that has been pulled from the repos
 
 There is also a property with the same name as the parent project's `type`, with different sub-fields depending on the project's `type` value (FIXME: details to be added).
+
+### Create a .scaffold-secrets.json
+
+The file must be created in your home directory.
+
+See the [sample file](./sample-scaffold-secrets.json) file for the JSON file structure.
+
+The JSON file has the following fields:
+* `default_github_oauth`: A required GitHub OAuth token which is used to access gitHub if no project specific tokens are provided.  See the [GitHub OAuth documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps) for details on how to create the token.
+* `projects`: Map of a project name to project specific secrets.  The project specific secrets include:
+  * `jira`: Optional Jira server and login information
+  * `whitesource`: Optional whitesource server authentication information
+  * `github_oauth`: Optional project specific GitHub OAuth token

--- a/docs/sample-scaffold-secrets.json
+++ b/docs/sample-scaffold-secrets.json
@@ -1,0 +1,18 @@
+{
+	"default_github_oauth": "githubOATHkey",
+	"projects":	{
+		"projectname": {
+			"jira": {
+					"server": "https://jira.server.url",
+					"username": "jirausername",
+					"password": "jirapassword",
+					"board": "board"
+			},
+			"whitesource": {
+				"apikey": "whitesourceapiKEY",
+				"userkey": "whitesourceUserKEY"
+			},
+			"github_oauth": "projectspecificOAUTHkey"
+		}
+	}
+}

--- a/repolisting.py
+++ b/repolisting.py
@@ -7,7 +7,7 @@ from gerrit import getGerritRepoDict, getGerritRepoList
 
 # Runner for START in GitHub
 def doRepoListingForSubproject(cfg, prj, sp):
-    allrepos = getGithubRepoList(cfg._gh_oauth_token, sp._github_org)
+    allrepos = getGithubRepoList(cfg._secrets._gitoauth[prj], sp._github_org)
 
     # first, figure out what repos need to be added
     for r in allrepos:
@@ -51,7 +51,7 @@ def doRepoListingForProject(cfg, prj):
                 allcfgrepos[r] = sp_name
 
         # collect all real repos currently on GitHub
-        allrealrepos = getGithubRepoList(cfg._gh_oauth_token, prj._github_shared_org)
+        allrealrepos = getGithubRepoList(cfg._secrets._gitoauth[prj], prj._github_shared_org)
 
         # first, figure out what repos need to be added
         for r in allrealrepos:

--- a/repolisting.py
+++ b/repolisting.py
@@ -7,7 +7,7 @@ from gerrit import getGerritRepoDict, getGerritRepoList
 
 # Runner for START in GitHub
 def doRepoListingForSubproject(cfg, prj, sp):
-    allrepos = getGithubRepoList(cfg._secrets._gitoauth[prj], sp._github_org)
+    allrepos = getGithubRepoList(cfg._secrets._gitoauth.get(prj._name), sp._github_org)
 
     # first, figure out what repos need to be added
     for r in allrepos:
@@ -51,7 +51,7 @@ def doRepoListingForProject(cfg, prj):
                 allcfgrepos[r] = sp_name
 
         # collect all real repos currently on GitHub
-        allrealrepos = getGithubRepoList(cfg._secrets._gitoauth[prj], prj._github_shared_org)
+        allrealrepos = getGithubRepoList(cfg._secrets._gitoauth.get(prj._name), prj._github_shared_org)
 
         # first, figure out what repos need to be added
         for r in allrealrepos:

--- a/scaffold.py
+++ b/scaffold.py
@@ -92,18 +92,6 @@ def fossdriverSetup(fossdriverrc_path):
 
     return server
 
-# FIXME move this into secrets file
-def githubOauthSetup():
-    scaffoldrc = os.path.join(Path.home(), ".scaffoldrc")
-    try:
-        with open(scaffoldrc, "r") as f:
-            js = json.load(f)
-            return js.get("gh_oauth_token", "")
-
-    except json.decoder.JSONDecodeError as e:
-        print(f'Error loading or parsing {scaffoldrc}: {str(e)}')
-        return ""
-
 if __name__ == "__main__":
     # check and parse year-month
     if len(sys.argv) < 2:
@@ -113,9 +101,6 @@ if __name__ == "__main__":
     if year == 0 and month == 0:
         printUsage()
         sys.exit(1)
-
-    # get github oauth token
-    GITHUB_OAUTH = githubOauthSetup()
 
     # get scaffold home directory
     SCAFFOLD_HOME = os.getenv('SCAFFOLD_HOME')
@@ -128,7 +113,6 @@ if __name__ == "__main__":
     # load configuration file for this month
     cfg_file = os.path.join(MONTH_DIR, "config.json")
     cfg = loadConfig(cfg_file, SCAFFOLD_HOME)
-    cfg._gh_oauth_token = GITHUB_OAUTH
 
     # we'll check if added optional args limit to one prj / sp
     prj_only = ""


### PR DESCRIPTION
Removes one of the configuration file requirements.

Secrets JSON format changed to:

```
{
	"default_github_oauth": "githubOATHkey",
	"projects":	{
		"projectname": {
			"jira": {
					"server": "https://jira.server.url",
					"username": "jirausername",
					"password": "jirapassword",
					"board": "board"
			},
			"whitesource": {
				"apikey": "whitesourceapiKEY",
				"userkey": "whitesourceUserKEY"
			}
		}
	}
}
```

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>