### PR TITLE
Close repositories after fetching code

### DIFF
--- a/getcode.py
+++ b/getcode.py
@@ -33,7 +33,6 @@ def doGetRepoCodeForSubproject(cfg, prj, sp):
     for repo in sp._repos:
         git_url = f"git@github.com:{org}/{repo}.git"
         print(f"{prj._name}/{sp._name}: cloning {git_url}")
-        git.Repo(ziporg_path, odbt=git.GitCmdObjectDB).clone_from(git_url, ziporg_path)
         git.Git(ziporg_path).clone(git_url)
         dotgit_path = os.path.join(ziporg_path, repo, ".git")
         # change branch if another is specified

--- a/getcode.py
+++ b/getcode.py
@@ -3,8 +3,7 @@
 
 from datetime import datetime
 import os
-import shutil
-import zipfile
+import util
 
 import git
 
@@ -25,7 +24,7 @@ def doGetRepoCodeForSubproject(cfg, prj, sp):
         ziporg_path = os.path.join(sp_path, sp._github_ziporg)
     # clear contents if it's already there
     if os.path.exists(ziporg_path):
-        shutil.rmtree(ziporg_path)
+        util.retry_rmtree(ziporg_path)
     # and create it if it isn't
     if not os.path.exists(ziporg_path):
         os.makedirs(ziporg_path)
@@ -78,7 +77,7 @@ def doGetRepoCodeForGerritSubproject(cfg, prj, sp):
     ziporg_path = os.path.join(sp_path, sp._name)
     # clear contents if it's already there
     if os.path.exists(ziporg_path):
-        shutil.rmtree(ziporg_path)
+        util.retry_rmtree(ziporg_path)
     # and create it if it isn't
     if not os.path.exists(ziporg_path):
         os.makedirs(ziporg_path)

--- a/util.py
+++ b/util.py
@@ -1,0 +1,31 @@
+# Copyright The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+'''
+Created on Nov 2, 2021
+
+@author: Gary O'Neall
+
+Utility class to support common function in Scaffold
+'''
+
+import shutil
+import time
+
+def retry_rmtree(path, max_retries=5):
+    """Calls shutil.rmtree and, if fails, retries up to the maximum number of retries
+    """
+    sleepTime = 1
+    for count in range(max_retries):
+        try:
+            shutil.rmtree(path)
+            return  # Success!
+        except OSError:
+            print("Error removing directory "+path)
+            if count < max_retries:
+                print("Retrying...")
+            time.sleep(sleepTime)
+            sleepTime = sleepTime * 2
+    # if we got here, we exceeded the 
+    # Try one more time and let the exception be thrown if unsuccessful
+    shutil.rmtree(path)

--- a/zipcode.py
+++ b/zipcode.py
@@ -1,12 +1,9 @@
 # Copyright The Linux Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime
 import os
-import shutil
 import zipfile
-
-import git
+import util
 
 from datatypes import ProjectRepoType, Status
 
@@ -23,13 +20,13 @@ def doZipRepoCodeForSubproject(cfg, prj, sp):
     # remove each repo's .git directory
     for repo in sp._repos:
         dotgit_path = os.path.join(ziporg_path, repo, ".git")
-        shutil.rmtree(dotgit_path)
+        util.retry_rmtree(dotgit_path)
         # also remove its repo-dirs-delete, if any
         delete_dirs = sp._repo_dirs_delete.get(repo, [])
         for delete_dir in delete_dirs:
             delete_dir_path = os.path.join(ziporg_path, repo, delete_dir)
             print(f"{prj._name}/{sp._name}: deleting {repo}:{delete_dir}")
-            shutil.rmtree(delete_dir_path)
+            util.retry_rmtree(delete_dir_path)
 
     # before zipping it all together, check and see whether it actually has any files
     if not sp._code_anyfiles:
@@ -53,7 +50,7 @@ def doZipRepoCodeForSubproject(cfg, prj, sp):
     zf.close()
 
     # and finally, remove the original unzipped directory
-    shutil.rmtree(ziporg_path)
+    util.retry_rmtree(ziporg_path)
 
     # success - advance state
     sp._status = Status.ZIPPEDCODE
@@ -71,13 +68,13 @@ def doZipRepoCodeForGerritSubproject(cfg, prj, sp):
         dashName = repo.replace("/", "-")
         dstFolder = os.path.join(ziporg_path, dashName)
         dotgit_path = os.path.join(dstFolder, ".git")
-        shutil.rmtree(dotgit_path)
+        util.retry_rmtree(dotgit_path)
         # also remove its repo-dirs-delete, if any
         delete_dirs = sp._repo_dirs_delete.get(repo, [])
         for delete_dir in delete_dirs:
             delete_dir_path = os.path.join(ziporg_path, dashName, delete_dir)
             print(f"{prj._name}/{sp._name}: deleting {repo}:{delete_dir}")
-            shutil.rmtree(delete_dir_path)
+            util.retry_rmtree(delete_dir_path)
 
     # before zipping it all together, check and see whether it actually has any files
     if not sp._code_anyfiles:
@@ -101,7 +98,7 @@ def doZipRepoCodeForGerritSubproject(cfg, prj, sp):
     zf.close()
 
     # and finally, remove the original unzipped directory
-    shutil.rmtree(ziporg_path)
+    util.retry_rmtree(ziporg_path)
 
     # success - advance state
     sp._status = Status.ZIPPEDCODE


### PR DESCRIPTION
Resolves issue #33 

Also adds a more robust rmtree to handle transient errors.