### PR TITLE
Add SPDX-FileCopyrightText & SPDX-FileType to source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ alias sc='python /INSTALL-LOCATION/scaffold/scaffold.py'
 ### Sbom
 
 To use the `sbom` command, [trivy](https://aquasecurity.github.io/trivy), [NPM](https://www.npmjs.com/), [Go](https://go.dev/) and [parlay](https://github.com/snyk/parlay) must be installed on the local machine.
-)
+
 The current version of Trivy and Parlay requires Go version 1.22.X installed on the target machine.
 
 To install Trivy:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install the requirements from requirements.txt: `pip install -r requirements.txt
 
 In order to shorten the amount of typing, I typically create an alias to `sc` in my `~/.bashrc` for calls to run scaffold:
 
-```
+```shell
 alias sc='python /INSTALL-LOCATION/scaffold/scaffold.py'
 ```
 
@@ -26,7 +26,7 @@ The current version of Trivy and Parlay requires Go version 1.22.X installed on 
 
 To install Trivy:
 
-```
+```shell
 git clone --depth 1 --branch v0.54.0 https://github.com/aquasecurity/trivy.git
 cd trivy
 go install ./cmd/trivy
@@ -36,7 +36,7 @@ The location of the Trivy command needs to be added to the config file and/or as
 
 To install Parlay:
 
-```
+```shell
 git clone --depth 1 --branch v0.5.1 https://github.com/snyk/parlay.git
 cd parlay
 go install .

--- a/approving.py
+++ b/approving.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datatypes import Status

--- a/clearing.py
+++ b/clearing.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datatypes import Status

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/createreports.py
+++ b/createreports.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/datatypes.py
+++ b/datatypes.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/datefuncs.py
+++ b/datefuncs.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime

--- a/delivering.py
+++ b/delivering.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datatypes import Status

--- a/emailing.py
+++ b/emailing.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datatypes import Status

--- a/findings.py
+++ b/findings.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import glob

--- a/gerrit.py
+++ b/gerrit.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict

--- a/getcode.py
+++ b/getcode.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime

--- a/getspdx.py
+++ b/getspdx.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/github.py
+++ b/github.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import requests

--- a/instancesfile.py
+++ b/instancesfile.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/manualsbom.py
+++ b/manualsbom.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import sbomagent

--- a/manualws.py
+++ b/manualws.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/metrics.py
+++ b/metrics.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/metricsfile.py
+++ b/metricsfile.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/newmonth.py
+++ b/newmonth.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import glob

--- a/parsespdx.py
+++ b/parsespdx.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/repolisting.py
+++ b/repolisting.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datatypes import ProjectRepoType, Status, Subproject

--- a/runagents.py
+++ b/runagents.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/runners.py
+++ b/runners.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime

--- a/runtests.py
+++ b/runtests.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 
 if __name__ == "__main__":

--- a/sbomagent.py
+++ b/sbomagent.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/scaffold.py
+++ b/scaffold.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path

--- a/slmjson.py
+++ b/slmjson.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/tickets.py
+++ b/tickets.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/transfer.py
+++ b/transfer.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/uploadcode.py
+++ b/uploadcode.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/uploadreport.py
+++ b/uploadreport.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/uploadspdx.py
+++ b/uploadspdx.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/uploadws.py
+++ b/uploadws.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/util.py
+++ b/util.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 '''

--- a/zipcode.py
+++ b/zipcode.py
@@ -1,4 +1,5 @@
-# Copyright The Linux Foundation
+# SPDX-FileCopyrightText: Copyright The Linux Foundation
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
 import os


### PR DESCRIPTION
In Python source files, replacing this header line:

```python
# Copyright The Linux Foundation
```

with  these two lines:

```python
# SPDX-FileCopyrightText: Copyright The Linux Foundation
# SPDX-FileType: SOURCE
```

Also removed one extra `)` in the README.