### PR TITLE
Update parser to use deprecated symbols

### DIFF
--- a/spdx/spdxutil.py
+++ b/spdx/spdxutil.py
@@ -19,6 +19,7 @@ from spdx_tools.spdx.model import SpdxNoAssertion
 from spdx_tools.spdx.model import SpdxNone
 from spdx_tools.spdx.parser.parse_anything import parse_file
 from spdx_tools.spdx.writer.write_anything import write_file
+from spdx_tools.common.spdx_licensing import spdx_licensing as tools_python_licensing
 import spdx_tools.spdx.document_utils as document_utils
 import spdx_tools.spdx.spdx_element_utils as spdx_element_utils
 from datatypes import ProjectRepoType
@@ -28,11 +29,10 @@ import os
 import json
 
 '''
-Gets the licensing parser for SPDX and adds back in missing symbols
+updates the licensing parser for SPDX and adds back in missing symbols
 for NONE, NOASSERTION and deprecated licenses
 '''
-def getLicensing():
-    licensing = get_spdx_licensing()
+def updateLicensing(licensing):
     licensing.known_symbols['NOASSERTION'] = LicenseSymbol('NOASSERTION')
     licensing.known_symbols['NONE'] = LicenseSymbol('NONE')
     licensing.known_symbols['AGPL-1.0'] = LicenseSymbol('AGPL-1.0')
@@ -103,6 +103,14 @@ def getLicensing():
     licensing.known_symbols_lowercase['nunit'] = LicenseSymbol('Nunit')
     licensing.known_symbols_lowercase['standardml-nj'] = LicenseSymbol('StandardML-NJ')
     licensing.known_symbols_lowercase['wxwindows'] = LicenseSymbol('wxWindows')
+
+'''
+Gets the licensing parser for SPDX and adds back in missing symbols
+for NONE, NOASSERTION and deprecated licenses
+'''
+def getLicensing():
+    licensing = get_spdx_licensing()
+    updateLicensing(licensing)
     return licensing
 
 '''
@@ -159,6 +167,7 @@ Parses an SPDX file with a supported file extension
 Raises SPDXParsingError on parsing errors
 '''
 def parseFile(file):
+    updateLicensing(tools_python_licensing)
     return parse_file(file)
 
 '''
@@ -166,7 +175,7 @@ wrties an SPDX document to a file in the format dictated by the file extension
 '''
 def writeFile(spdx_document, file):
     write_file(spdx_document, file, validate=False)
-    print("SPDX sucessfully written")
+    print("SPDX successfully written")
     
 def augmentTrivyDocument(spdx_document, cfg, prj, sp):
     remove_dup_packages(spdx_document)

--- a/spdx/spdxutil.py
+++ b/spdx/spdxutil.py
@@ -3,7 +3,7 @@
 
 # Utility class to support merging / fixing up SPDX documents
 
-from license_expression import get_spdx_licensing
+from license_expression import get_spdx_licensing, LicenseSymbol
 from spdx_tools.spdx.model.package import Package
 from spdx_tools.spdx.model.package import ExternalPackageRef
 from spdx_tools.spdx.model.package import ExternalPackageRefCategory
@@ -28,6 +28,84 @@ import os
 import json
 
 '''
+Gets the licensing parser for SPDX and adds back in missing symbols
+for NONE, NOASSERTION and deprecated licenses
+'''
+def getLicensing():
+    licensing = get_spdx_licensing()
+    licensing.known_symbols['NOASSERTION'] = LicenseSymbol('NOASSERTION')
+    licensing.known_symbols['NONE'] = LicenseSymbol('NONE')
+    licensing.known_symbols['AGPL-1.0'] = LicenseSymbol('AGPL-1.0')
+    licensing.known_symbols['AGPL-3.0'] = LicenseSymbol('AGPL-3.0')
+    licensing.known_symbols['BSD-2-Clause-FreeBSD'] = LicenseSymbol('BSD-2-Clause-FreeBSD')
+    licensing.known_symbols['BSD-2-Clause-NetBSD'] = LicenseSymbol('BSD-2-Clause-NetBSD')
+    licensing.known_symbols['bzip2-1.0.5'] = LicenseSymbol('bzip2-1.0.5')
+    licensing.known_symbols['eCos-2.0'] = LicenseSymbol('eCos-2.0')
+    licensing.known_symbols['GFDL-1.1'] = LicenseSymbol('GFDL-1.1')
+    licensing.known_symbols['GFDL-1.2'] = LicenseSymbol('GFDL-1.2')
+    licensing.known_symbols['GFDL-1.3'] = LicenseSymbol('GFDL-1.3')
+    licensing.known_symbols['GPL-1.0'] = LicenseSymbol('GPL-1.0')
+    licensing.known_symbols['GPL-1.0+'] = LicenseSymbol('GPL-1.0+')
+    licensing.known_symbols['GPL-2.0'] = LicenseSymbol('GPL-2.0')
+    licensing.known_symbols['GPL-2.0+'] = LicenseSymbol('GPL-2.0+')
+    licensing.known_symbols['GPL-2.0-with-autoconf-exception'] = LicenseSymbol('GPL-2.0-with-autoconf-exception')
+    licensing.known_symbols['GPL-2.0-with-bison-exception'] = LicenseSymbol('GPL-2.0-with-bison-exception')
+    licensing.known_symbols['GPL-2.0-with-classpath-exception'] = LicenseSymbol('GPL-2.0-with-classpath-exception')
+    licensing.known_symbols['GPL-2.0-with-font-exception'] = LicenseSymbol('GPL-2.0-with-font-exception')
+    licensing.known_symbols['GPL-2.0-with-GCC-exception'] = LicenseSymbol('GPL-2.0-with-GCC-exception')
+    licensing.known_symbols['GPL-3.0'] = LicenseSymbol('GPL-3.0')
+    licensing.known_symbols['GPL-3.0+'] = LicenseSymbol('GPL-3.0+')
+    licensing.known_symbols['GPL-3.0-with-autoconf-exception'] = LicenseSymbol('GPL-3.0-with-autoconf-exception')
+    licensing.known_symbols['GPL-3.0-with-GCC-exception'] = LicenseSymbol('GPL-3.0-with-GCC-exception')
+    licensing.known_symbols['LGPL-2.0'] = LicenseSymbol('LGPL-2.0')
+    licensing.known_symbols['LGPL-2.0+'] = LicenseSymbol('LGPL-2.0+')
+    licensing.known_symbols['LGPL-2.1'] = LicenseSymbol('LGPL-2.1')
+    licensing.known_symbols['LGPL-2.1+'] = LicenseSymbol('LGPL-2.1+')
+    licensing.known_symbols['LGPL-3.0'] = LicenseSymbol('LGPL-3.0')
+    licensing.known_symbols['LGPL-3.0+'] = LicenseSymbol('LGPL-3.0+')
+    licensing.known_symbols['Net-SNMP'] = LicenseSymbol('Net-SNMP')
+    licensing.known_symbols['Nunit'] = LicenseSymbol('Nunit')
+    licensing.known_symbols['StandardML-NJ'] = LicenseSymbol('StandardML-NJ')
+    licensing.known_symbols['wxWindows'] = LicenseSymbol('wxWindows')
+
+
+    licensing.known_symbols_lowercase['noassertion'] = LicenseSymbol('NOASSERTION')
+    licensing.known_symbols_lowercase['none'] = LicenseSymbol('NONE')
+    licensing.known_symbols_lowercase['agpl-1.0'] = LicenseSymbol('AGPL-1.0')
+    licensing.known_symbols_lowercase['agpl-3.0'] = LicenseSymbol('AGPL-3.0')
+    licensing.known_symbols_lowercase['bsd-2-clause-freebsd'] = LicenseSymbol('BSD-2-Clause-FreeBSD')
+    licensing.known_symbols_lowercase['bsd-2-clause-netbsd'] = LicenseSymbol('BSD-2-Clause-NetBSD')
+    licensing.known_symbols_lowercase['bzip2-1.0.5'] = LicenseSymbol('bzip2-1.0.5')
+    licensing.known_symbols_lowercase['ecos-2.0'] = LicenseSymbol('eCos-2.0')
+    licensing.known_symbols_lowercase['gfdl-1.1'] = LicenseSymbol('GFDL-1.1')
+    licensing.known_symbols_lowercase['gfdl-1.2'] = LicenseSymbol('GFDL-1.2')
+    licensing.known_symbols_lowercase['gfdl-1.3'] = LicenseSymbol('GFDL-1.3')
+    licensing.known_symbols_lowercase['gpl-1.0'] = LicenseSymbol('GPL-1.0')
+    licensing.known_symbols_lowercase['gpl-1.0+'] = LicenseSymbol('GPL-1.0+')
+    licensing.known_symbols_lowercase['gpl-2.0'] = LicenseSymbol('GPL-2.0')
+    licensing.known_symbols_lowercase['gpl-2.0+'] = LicenseSymbol('GPL-2.0+')
+    licensing.known_symbols_lowercase['gpl-2.0-with-autoconf-exception'] = LicenseSymbol('GPL-2.0-with-autoconf-exception')
+    licensing.known_symbols_lowercase['gpl-2.0-with-bison-exception'] = LicenseSymbol('GPL-2.0-with-bison-exception')
+    licensing.known_symbols_lowercase['gpl-2.0-with-classpath-exception'] = LicenseSymbol('GPL-2.0-with-classpath-exception')
+    licensing.known_symbols_lowercase['gpl-2.0-with-font-exception'] = LicenseSymbol('GPL-2.0-with-font-exception')
+    licensing.known_symbols_lowercase['gpl-2.0-with-gcc-exception'] = LicenseSymbol('GPL-2.0-with-GCC-exception')
+    licensing.known_symbols_lowercase['gpl-3.0'] = LicenseSymbol('GPL-3.0')
+    licensing.known_symbols_lowercase['gpl-3.0+'] = LicenseSymbol('GPL-3.0+')
+    licensing.known_symbols_lowercase['gpl-3.0-with-autoconf-exception'] = LicenseSymbol('GPL-3.0-with-autoconf-exception')
+    licensing.known_symbols_lowercase['gpl-3.0-with-gcc-exception'] = LicenseSymbol('GPL-3.0-with-GCC-exception')
+    licensing.known_symbols_lowercase['lgpl-2.0'] = LicenseSymbol('LGPL-2.0')
+    licensing.known_symbols_lowercase['lgpl-2.0+'] = LicenseSymbol('LGPL-2.0+')
+    licensing.known_symbols_lowercase['lgpl-2.1'] = LicenseSymbol('LGPL-2.1')
+    licensing.known_symbols_lowercase['lgpl-2.1+'] = LicenseSymbol('LGPL-2.1+')
+    licensing.known_symbols_lowercase['lgpl-3.0'] = LicenseSymbol('LGPL-3.0')
+    licensing.known_symbols_lowercase['lgpl-3.0+'] = LicenseSymbol('LGPL-3.0+')
+    licensing.known_symbols_lowercase['net-snmp'] = LicenseSymbol('Net-SNMP')
+    licensing.known_symbols_lowercase['nunit'] = LicenseSymbol('Nunit')
+    licensing.known_symbols_lowercase['standardml-nj'] = LicenseSymbol('StandardML-NJ')
+    licensing.known_symbols_lowercase['wxwindows'] = LicenseSymbol('wxWindows')
+    return licensing
+
+'''
 Parses the SPDX JSON file for any license expressions that do not parse
 Fix these license by converting them to an extracted license info
 '''
@@ -35,7 +113,7 @@ def fixLicenseExpressions(fileName):
     with open(fileName, 'r', encoding='utf-8') as file:
         spdxJson = json.load(file)
     extractedLicenseText = {}
-    licensing = get_spdx_licensing()
+    licensing = getLicensing()
     _fix_license_expressions(spdxJson, extractedLicenseText, licensing)
     if extractedLicenseText:
         if 'hasExtractedLicensingInfos' in spdxJson:
@@ -92,7 +170,7 @@ def writeFile(spdx_document, file):
     
 def augmentTrivyDocument(spdx_document, cfg, prj, sp):
     remove_dup_packages(spdx_document)
-    licensing = get_spdx_licensing()
+    licensing = getLicensing()
     # find the root of the document
     describes = None
     for relationship in spdx_document.relationships:

--- a/tests/testspdxutil.py
+++ b/tests/testspdxutil.py
@@ -1,6 +1,6 @@
 # Copyright The Linux Foundation
 # SPDX-License-Identifier: Apache-2.0
-import pdb
+
 import unittest
 import os
 import tempfile
@@ -8,21 +8,15 @@ import shutil
 import spdx.spdxutil as spdxutil
 import spdx.xlsx as xlsx
 from config import loadConfig
-from spdx_tools.spdx.model.document import Document
 from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.package import ExternalPackageRef
 from spdx_tools.spdx.model.package import ExternalPackageRefCategory
 from spdx_tools.spdx.model.package import PackagePurpose
 from spdx_tools.spdx.model.actor import ActorType
-from spdx_tools.spdx.model.relationship import Relationship
 from spdx_tools.spdx.model.relationship import RelationshipType
-from spdx_tools.spdx.model import SpdxNoAssertion
-from spdx_tools.spdx.model import SpdxNone
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 import spdx_tools.spdx.document_utils as document_utils
 import spdx_tools.spdx.spdx_element_utils as spdx_element_utils
 from license_expression import LicenseSymbol
-import re
 import json
 
 TRIVY_SPDX_FILENAME = "test-trivy-spdx.json"


### PR DESCRIPTION
Fixes #147

Does not validate due to the Python tools using a license expression parser without the deprecated licenses

This does not pass unit tests - hence draft mode